### PR TITLE
Add clipboard utility with browser fallback and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ maha-evidence-engine/
 └── README.md
 ```
 
+## 🔗 Clipboard Sharing
+
+The web app includes a `copyToClipboard` utility that uses the modern Clipboard API when available and gracefully falls back to legacy `document.execCommand('copy')` behavior. This ensures links can be copied in all supported browsers.
+
 ## 🎨 Branding Customization
 
 ### One-Step Rebranding Process

--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -13,8 +13,9 @@ jest.mock('next/image', () => ({
 // Mock Next.js Link component
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ children, href }) => {
-    return <a href={href}>{children}</a>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  default: ({ children, href, ...rest }) => {
+    return <a href={href} {...rest}>{children}</a>
   },
 }))
 

--- a/apps/web/src/components/CopyButton.tsx
+++ b/apps/web/src/components/CopyButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { copyToClipboard } from '@/utils/clipboard';
+
+interface CopyButtonProps {
+  text?: string;
+  label?: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({ text, label = 'Copy URL' }) => {
+  const handleClick = () => {
+    const value = text ?? window.location.href;
+    copyToClipboard(value);
+  };
+
+  return (
+    <button onClick={handleClick} className="hover:text-accent" aria-label={label}>
+      {label}
+    </button>
+  );
+};
+
+export default CopyButton;

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import siteConfig from '@/../branding/site.json';
+import siteConfig from '../../../../branding/site.json';
+import CopyButton from './CopyButton';
 
 const Header: React.FC = () => {
   return (
@@ -20,6 +21,7 @@ const Header: React.FC = () => {
           <li><Link href="/" className="hover:text-accent">Home</Link></li>
           <li><Link href="/maps" className="hover:text-accent">Maps</Link></li>
           <li><Link href="/atlas" className="hover:text-accent">Atlas</Link></li>
+          <li><CopyButton /></li>
         </ul>
       </nav>
     </header>

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -32,6 +32,12 @@ describe('Header Component', () => {
     expect(atlasLink).toHaveAttribute('href', '/atlas');
   });
 
+  it('includes a copy URL button', () => {
+    render(<Header />);
+    const button = screen.getByRole('button', { name: /copy url/i });
+    expect(button).toBeInTheDocument();
+  });
+
   it('applies correct CSS classes for branding', () => {
     render(<Header />);
     const header = screen.getByRole('banner');

--- a/apps/web/src/utils/__tests__/clipboard.test.ts
+++ b/apps/web/src/utils/__tests__/clipboard.test.ts
@@ -1,0 +1,42 @@
+import { copyToClipboard } from '../clipboard';
+
+describe('copyToClipboard', () => {
+  const originalClipboard = (navigator as any).clipboard;
+
+  beforeEach(() => {
+    (document as any).execCommand = jest.fn();
+  });
+
+  afterEach(() => {
+    (navigator as any).clipboard = originalClipboard;
+    jest.clearAllMocks();
+  });
+
+  it('uses navigator.clipboard.writeText when available', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    (navigator as any).clipboard = { writeText };
+
+    await copyToClipboard('hello');
+
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(document.execCommand).not.toHaveBeenCalled();
+  });
+
+  it('falls back to execCommand when clipboard API is missing', async () => {
+    (navigator as any).clipboard = undefined;
+
+    await copyToClipboard('fallback');
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('falls back to execCommand when clipboard API rejects', async () => {
+    const writeText = jest.fn().mockRejectedValue(new Error('fail'));
+    (navigator as any).clipboard = { writeText };
+
+    await copyToClipboard('error');
+
+    expect(writeText).toHaveBeenCalled();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+});

--- a/apps/web/src/utils/clipboard.ts
+++ b/apps/web/src/utils/clipboard.ts
@@ -1,0 +1,23 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}


### PR DESCRIPTION
## Summary
- add copyToClipboard utility that falls back to document.execCommand for older browsers
- add CopyButton component and expose Copy URL button in header
- test Clipboard API fallback scenarios and update README

## Testing
- `cd apps/web && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb29a715c8328bb209c96aac0326b