### PR TITLE
fix branding path and link mock

### DIFF
--- a/apps/web/jest.setup.js
+++ b/apps/web/jest.setup.js
@@ -11,10 +11,16 @@ jest.mock('next/image', () => ({
 }))
 
 // Mock Next.js Link component
+// Mock Next.js Link component and forward all props so styles and other
+// attributes like `className` are preserved in tests
 jest.mock('next/link', () => ({
   __esModule: true,
-  default: ({ children, href }) => {
-    return <a href={href}>{children}</a>
+  default: ({ children, href, ...props }) => {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
   },
 }))
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
-import siteConfig from "@/../branding/site.json";
+// Import site configuration from monorepo root branding folder
+import siteConfig from "../../../../branding/site.json";
 
 export default function Home() {
   const jsonLd = {
@@ -48,7 +49,7 @@ export default function Home() {
           <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
             <h3 className="text-xl font-semibold mb-3 text-primary">Curcumin & Cancer</h3>
             <p className="text-gray-600 mb-4">
-              Explore evidence on curcumin's potential anti-cancer properties and mechanisms.
+              Explore evidence on curcumin&apos;s potential anti-cancer properties and mechanisms.
             </p>
             <a href="/maps?query=curcumin+cancer" className="text-accent hover:underline">
               View Research →
@@ -57,7 +58,7 @@ export default function Home() {
           <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
             <h3 className="text-xl font-semibold mb-3 text-primary">Berberine & Diabetes</h3>
             <p className="text-gray-600 mb-4">
-              Discover studies on berberine's effects on blood sugar and metabolic health.
+              Discover studies on berberine&apos;s effects on blood sugar and metabolic health.
             </p>
             <a href="/maps?query=berberine+diabetes" className="text-accent hover:underline">
               View Research →

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import siteConfig from '@/../branding/site.json';
+// Import site branding configuration from the repository root
+// The previous path attempted to go only one level up from `src`,
+// resolving to `apps/web/branding/site.json` which doesn't exist.
+// We need to traverse up to the monorepo root to reach the shared
+// `branding/site.json` file.
+import siteConfig from '../../../../branding/site.json';
 
 const Header: React.FC = () => {
   return (


### PR DESCRIPTION
## Summary
- fix branding import path for header and home page
- preserve className in Next.js Link mock for tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cb2ae816c8328a0d980b8eb3d9174