### PR TITLE
docs: add repository overview for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Perfect for:
 
 A scientific evidence mapping platform that integrates Open Knowledge Maps with a custom Next.js 14 shell, featuring full MAHA branding and EviAtlas integration.
 
+If you're new to the project, check out [docs/overview.md](docs/overview.md) for a guided tour of the repository.
+
 ![MAHA Evidence Engine](./branding/maha-logo.svg)
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/just-goingviral/maha-evidence-engine/ci.yml?branch=main&style=for-the-badge)](https://github.com/just-goingviral/maha-evidence-engine/actions)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,40 @@
+# Repository Overview
+
+Welcome to the **MAHA Evidence Engine** codebase. This document provides a high-level tour of the repository to help new contributors quickly find their way around.
+
+## Key Directories
+
+- **apps/** – Application source code. Each subdirectory represents a standalone service.
+  - **web/** – Next.js 14 front‑end that drives the main MAHA site.
+  - **headstart/** – Integration with Open Knowledge Maps for visualising research networks.
+  - **eviatlas/** – R/Shiny service that renders evidence heatmaps.
+- **packages/** – Shared libraries used across apps. Currently contains the `ui` component library.
+- **branding/** – Logos, colours, and other assets used to customise the MAHA look and feel.
+- **data/** – Example datasets and seed files used for demos and development.
+- **ops/** – Operational tooling such as Docker configuration.
+- **deploy.sh** – Helper script for deploying the stack.
+
+## Common Tasks
+
+### Local development
+
+```bash
+# Start all services with Docker
+cp .env.example .env
+docker compose up --build
+```
+
+### Running tests for the web app
+
+```bash
+npm test --prefix apps/web
+```
+
+### Linting the web app
+
+```bash
+npm run lint --prefix apps/web
+```
+
+For more details on contributing, see [CONTRIBUTING.md](../CONTRIBUTING.md) and the main [README](../README.md).
+


### PR DESCRIPTION
## Summary
- document repository layout and common tasks in `docs/overview.md`
- reference the overview from the main README

## Testing
- `npm test --prefix apps/web` *(fails: Cannot find module '../../branding/site.json')*
- `npm run lint --prefix apps/web` *(fails: react/no-unescaped-entities in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689cb2a380a883289f11d8c9b896ce6f