### PR TITLE
Add medical disclaimer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Access the application at:
 - Main site: http://localhost
 - Knowledge Maps: http://localhost/maps
 - Evidence Atlas: http://localhost/atlas
+- Disclaimer: http://localhost/disclaimer
 
 ## 📋 Prerequisites
 

--- a/apps/web/src/app/disclaimer/page.tsx
+++ b/apps/web/src/app/disclaimer/page.tsx
@@ -1,0 +1,18 @@
+export default function DisclaimerPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 py-16">
+      <div className="container mx-auto px-4 max-w-3xl">
+        <h1 className="text-4xl font-bold mb-6 text-gray-800">Medical Information Disclaimer</h1>
+        <p className="text-gray-700 mb-4">
+          The information provided on this site is for educational purposes only and is not intended as a substitute for professional medical advice, diagnosis, or treatment.
+        </p>
+        <p className="text-gray-700 mb-4">
+          Always seek the guidance of a qualified health provider with any questions you may have regarding your health or a medical condition. Never disregard professional medical advice or delay seeking it because of information you have read on this site.
+        </p>
+        <p className="text-gray-700">
+          If you think you may be experiencing a medical emergency, call your doctor or emergency services immediately.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -114,6 +114,11 @@ export default function Home() {
         <div className="container mx-auto px-4 text-center">
           <p className="mb-2">© 2025 MAHA Evidence Engine. All rights reserved.</p>
           <p className="text-gray-400">Empowering evidence-based natural healing research</p>
+          <p className="mt-2">
+            <a href="/disclaimer" className="text-gray-400 hover:underline">
+              Medical information disclaimer
+            </a>
+          </p>
         </div>
       </footer>
     </main>


### PR DESCRIPTION
## Summary
- add `/disclaimer` page explaining that content is not medical advice
- link the disclaimer page in the homepage footer
- mention the disclaimer route in the README

## Testing
- `npm test` *(fails: Rest element must be final element in jest.setup.js)*
- `npm run lint` *(fails: Unexpected any in clipboard.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f637490c83289365a1a1a19ef93c