### PR TITLE
chore: tighten csp with nonces

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,26 @@ The project maintains a minimum test coverage of 80% for:
 
 ### Security Features
 
-- Content Security Policy (CSP) headers
+- Strict Content Security Policy (CSP) with per-request nonces
 - CORS configuration
 - Rate limiting (10 requests/second)
 - Security headers (X-Frame-Options, X-XSS-Protection, etc.)
 - Regular dependency updates via Dependabot
 - Vulnerability scanning with Trivy
+
+### Content Security Policy
+
+The application sets a restrictive CSP that removes `'unsafe-inline'` and `'unsafe-eval'` from `script-src` and disallows inline styles unless a nonce is present. A unique nonce is generated for every request in [`apps/web/src/middleware.ts`](apps/web/src/middleware.ts) and exposed via the `x-nonce` header. Inline `<script>` or `<style>` tags must include this nonce:
+
+```tsx
+import { headers } from "next/headers";
+
+const nonce = headers().get("x-nonce") || undefined;
+
+<script nonce={nonce} />
+```
+
+Next.js automatically applies the nonce to its internal inline styles and scripts during both development and production builds.
 
 ### Security Audits
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,10 @@
 // Import site configuration from monorepo root branding folder
 import siteConfig from "../../../../branding/site.json";
+import { headers } from "next/headers";
 
 export default function Home() {
+  const cspNonce = headers().get("x-nonce") || undefined;
+
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "WebSite",
@@ -17,6 +20,7 @@ export default function Home() {
   return (
     <main className="min-h-screen bg-gray-50">
       <script
+        nonce={cspNonce}
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,7 +2,13 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  const response = NextResponse.next();
+  const nonce = crypto.randomUUID();
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
 
   // Security headers
   response.headers.set('X-Content-Type-Options', 'nosniff');
@@ -14,8 +20,8 @@ export function middleware(request: NextRequest) {
   // Content Security Policy
   const csp = [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-    "style-src 'self' 'unsafe-inline'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    `style-src 'self' 'nonce-${nonce}'`,
     "img-src 'self' data: https:",
     "font-src 'self'",
     "connect-src 'self'",


### PR DESCRIPTION
## Summary
- remove unsafe-inline and unsafe-eval from script-src
- generate per-request nonce and apply to script and style CSP directives
- document stricter CSP and nonce usage

## Testing
- `npm test` *(fails: Rest element must be final element)*
- `npm run lint` *(fails: no-explicit-any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f638f310832887919d65eb119e14