### PR TITLE
feat(web): use environment site URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NODE_ENV=production
 PORT=3000
 NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_SITE_URL=http://localhost
 
 # Headstart Configuration
 HEADSTART_API_URL=http://headstart:8080

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Key environment variables (see `.env.example` for full list):
 
 - `NODE_ENV` - Environment (development/production)
 - `NEXT_PUBLIC_API_URL` - Public API URL
+- `NEXT_PUBLIC_SITE_URL` - Public site URL
 - `HEADSTART_API_URL` - Headstart service URL
 - `SESSION_SECRET` - Session encryption key
 - `CORS_ORIGIN` - Allowed CORS origins

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import siteConfig from "@/../branding/site.json";
 import Header from "@/components/Header";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -24,11 +25,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: siteConfig.siteName,
     description: siteConfig.tagline,
-    url: "https://maha-evidence-engine.vercel.app", // Replace with actual production URL
+    url: siteUrl,
     siteName: siteConfig.siteName,
     images: [
       {
-        url: "https://maha-evidence-engine.vercel.app/og-image.png", // Replace with actual image URL
+        url: `${siteUrl}/og-image.png`,
         width: 1200,
         height: 630,
       },
@@ -40,7 +41,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: siteConfig.siteName,
     description: siteConfig.tagline,
-    images: ["https://maha-evidence-engine.vercel.app/og-image.png"], // Replace with actual image URL
+    images: [`${siteUrl}/og-image.png`],
   },
   robots: {
     index: true,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,15 +1,17 @@
 // Import site configuration from monorepo root branding folder
 import siteConfig from "../../../../branding/site.json";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost";
+
 export default function Home() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     name: siteConfig.siteName,
-    url: "https://maha-evidence-engine.vercel.app", // Replace with actual production URL
+    url: siteUrl,
     potentialAction: {
       "@type": "SearchAction",
-      target: "https://maha-evidence-engine.vercel.app/maps?query={search_term_string}", // Replace with actual production URL
+      target: `${siteUrl}/maps?query={search_term_string}`,
       "query-input": "required name=search_term_string",
     },
   };


### PR DESCRIPTION
## Summary
- read NEXT_PUBLIC_SITE_URL for OpenGraph metadata and schema JSON
- document NEXT_PUBLIC_SITE_URL in example env and README

## Testing
- `npm test` *(fails: Rest element must be final element)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f63ebea48328a3c2f0e6f0e92daf