### PR TITLE
feat: map review metadata to internal schema

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -4,14 +4,17 @@ jest.mock('next/server', () => ({
   },
 }));
 
-import { middleware } from '../middleware';
+import type { NextRequest } from 'next/server'
+import { middleware } from '../middleware'
 
 type MockRequest = { nextUrl: { pathname: string }; headers: Headers };
+
+// Cast our simple object to NextRequest in tests to satisfy middleware signature without using `any`.
 
 describe('middleware', () => {
   it('sets security headers on every response', () => {
     const request: MockRequest = { nextUrl: { pathname: '/' }, headers: new Headers() };
-    const response = middleware(request as any);
+    const response = middleware(request as unknown as NextRequest)
     expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
     expect(response.headers.get('X-Frame-Options')).toBe('DENY');
     expect(response.headers.get('X-XSS-Protection')).toBe('1; mode=block');
@@ -26,7 +29,7 @@ describe('middleware', () => {
       nextUrl: { pathname: '/api/data' },
       headers: new Headers({ origin: 'http://allowed.com' }),
     };
-    const response = middleware(request as any);
+    const response = middleware(request as unknown as NextRequest)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('http://allowed.com');
     expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, PUT, DELETE, OPTIONS');
     expect(response.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization');
@@ -40,7 +43,7 @@ describe('middleware', () => {
       nextUrl: { pathname: '/api/data' },
       headers: new Headers({ origin: 'http://notallowed.com' }),
     };
-    const response = middleware(request as any);
+    const response = middleware(request as unknown as NextRequest)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
     delete process.env.CORS_ORIGIN;
   });

--- a/apps/web/src/utils/__tests__/schemaMapping.test.ts
+++ b/apps/web/src/utils/__tests__/schemaMapping.test.ts
@@ -1,0 +1,43 @@
+import { mapReviewToEvidence, ReviewRecord } from '@/utils/schemaMapping'
+
+describe('mapReviewToEvidence', () => {
+  it('maps known fields to EvidenceRecord', () => {
+    const review: ReviewRecord = {
+      doi: '10.1000/xyz123',
+      pmid: '987654',
+      title: 'Sample Review',
+      authors: ['Alice', 'Bob'],
+      publicationDate: '2024-01-01',
+      type: 'meta_analysis',
+      outcomes: ['Outcome1', 'Outcome2'],
+    }
+
+    const evidence = mapReviewToEvidence(review)
+
+    expect(evidence).toEqual({
+      id: '10.1000/xyz123',
+      title: 'Sample Review',
+      authors: ['Alice', 'Bob'],
+      publicationDate: '2024-01-01',
+      type: 'meta-analysis',
+      outcomes: ['Outcome1', 'Outcome2'],
+    })
+  })
+
+  it('falls back gracefully when optional fields are missing', () => {
+    const review: ReviewRecord = {
+      title: 'Untitled Review',
+    }
+
+    const evidence = mapReviewToEvidence(review)
+
+    expect(evidence).toEqual({
+      id: 'Untitled Review',
+      title: 'Untitled Review',
+      authors: [],
+      publicationDate: undefined,
+      type: 'systematic-review',
+      outcomes: [],
+    })
+  })
+})

--- a/apps/web/src/utils/schemaMapping.ts
+++ b/apps/web/src/utils/schemaMapping.ts
@@ -1,0 +1,41 @@
+export interface ReviewRecord {
+  /** Unique identifier for the review or meta-analysis. Prefers DOI, then PMID. */
+  doi?: string
+  pmid?: string
+  id?: string
+  title: string
+  authors?: string[]
+  publicationDate?: string
+  type?: 'systematic_review' | 'meta_analysis' | string
+  outcomes?: string[]
+}
+
+export type EvidenceType = 'systematic-review' | 'meta-analysis'
+
+export interface EvidenceRecord {
+  id: string
+  title: string
+  authors: string[]
+  publicationDate?: string
+  type: EvidenceType
+  outcomes: string[]
+}
+
+/**
+ * Map an external review/meta-analysis record into the canonical Evidence Engine schema.
+ * Fields are normalised to match the internal ontology so downstream consumers can rely on
+ * consistent naming regardless of source.
+ */
+export function mapReviewToEvidence(review: ReviewRecord): EvidenceRecord {
+  const id = review.doi ?? review.pmid ?? review.id ?? review.title
+  const type: EvidenceType = review.type === 'meta_analysis' ? 'meta-analysis' : 'systematic-review'
+
+  return {
+    id,
+    title: review.title,
+    authors: review.authors ?? [],
+    publicationDate: review.publicationDate,
+    type,
+    outcomes: review.outcomes ?? [],
+  }
+}


### PR DESCRIPTION
## Summary
- add mapping utility to normalise review and meta-analysis metadata into Evidence Engine schema
- cover mapping behaviour with unit tests
- type middleware tests to avoid `any` casts

## Testing
- `npm run lint --prefix apps/web`
- `npm test --prefix apps/web`


------
https://chatgpt.com/codex/tasks/task_e_68c489bc5898832880e35ef8f64514ca