### PR TITLE
feat(web): add evidence scope toggle

### DIFF
--- a/apps/web/src/app/maps/page.tsx
+++ b/apps/web/src/app/maps/page.tsx
@@ -4,7 +4,11 @@ interface MapsPageProps {
 
 export default function MapsPage({ searchParams }: MapsPageProps) {
   const query = searchParams.query ? String(searchParams.query) : '';
-  const src = `/api/headstart${query ? `?query=${encodeURIComponent(query)}` : ''}`;
+  const scope = searchParams.scope ? String(searchParams.scope) : '';
+  const params = new URLSearchParams();
+  if (query) params.set('query', query);
+  if (scope) params.set('scope', scope);
+  const src = `/api/headstart${params.toString() ? `?${params.toString()}` : ''}`;
 
   return (
     <iframe

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import siteConfig from '../../../../branding/site.json';
 import CopyButton from './CopyButton';
+import ScopeToggle from './ScopeToggle';
 
 const Header: React.FC = () => {
   const pathname = usePathname();
@@ -30,6 +31,7 @@ const Header: React.FC = () => {
           <li><Link href="/" className="hover:text-accent">Home</Link></li>
           <li><Link href="/maps" className="hover:text-accent">Maps</Link></li>
           <li><Link href="/atlas" className="hover:text-accent">Atlas</Link></li>
+          <li><ScopeToggle /></li>
           <li><CopyButton /></li>
         </ul>
       </nav>

--- a/apps/web/src/components/ScopeToggle.tsx
+++ b/apps/web/src/components/ScopeToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+const options = [
+  { value: "all", label: "All" },
+  { value: "gold", label: "Gold Standard" },
+  { value: "rcts", label: "RCTs" },
+];
+
+export default function ScopeToggle() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const currentScope = searchParams.get("scope") || "all";
+
+  const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("scope", e.target.value);
+    const query = params.toString();
+    router.push(`${pathname}${query ? `?${query}` : ""}`);
+  };
+
+  return (
+    <select
+      aria-label="Evidence scope"
+      value={currentScope}
+      onChange={onChange}
+      className="text-black rounded p-1"
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Header from '../Header';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+  useRouter: jest.fn(),
 }));
 
 const mockUsePathname = usePathname as jest.Mock;
+const mockUseSearchParams = useSearchParams as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
 
 beforeEach(() => {
   mockUsePathname.mockReturnValue('/');
+  mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  mockUseRouter.mockReturnValue({ push: jest.fn() });
 });
 
 describe('Header Component', () => {
@@ -62,6 +68,12 @@ describe('Header Component', () => {
     render(<Header />);
     const button = screen.getByRole('button', { name: /copy url/i });
     expect(button).toBeInTheDocument();
+  });
+
+  it('renders evidence scope toggle', () => {
+    render(<Header />);
+    const select = screen.getByRole('combobox', { name: /evidence scope/i });
+    expect(select).toBeInTheDocument();
   });
 
   it('applies correct CSS classes for branding', () => {

--- a/apps/web/src/components/__tests__/ScopeToggle.test.tsx
+++ b/apps/web/src/components/__tests__/ScopeToggle.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ScopeToggle from '../ScopeToggle';
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+describe('ScopeToggle', () => {
+  const mockPush = jest.fn();
+
+  beforeEach(() => {
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams());
+    (usePathname as jest.Mock).mockReturnValue('/maps');
+    (useRouter as jest.Mock).mockReturnValue({ push: mockPush });
+    mockPush.mockClear();
+  });
+
+  it('renders all scope options', () => {
+    render(<ScopeToggle />);
+    const select = screen.getByRole('combobox', { name: /evidence scope/i });
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'All' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Gold Standard' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'RCTs' })).toBeInTheDocument();
+  });
+
+  it('updates the URL when the scope changes', () => {
+    render(<ScopeToggle />);
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'gold' },
+    });
+    expect(mockPush).toHaveBeenCalledWith('/maps?scope=gold');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add ScopeToggle component to switch evidence scope
- wire toggle into header and maps page
- cover scope selection with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c489c3fbf483288a0e11610fc05859